### PR TITLE
Fix computation of speed for ContainerDependentMovable in Simulation

### DIFF
--- a/digital_twin/model.py
+++ b/digital_twin/model.py
@@ -588,7 +588,9 @@ def get_kwargs_from_properties(environment, name, properties, sites):
     if "speed" in properties:
         speed = properties["speed"]
         if isinstance(speed, list):
-            compute_function = get_compute_function(speed, "level", "speed")
+            df = pd.DataFrame(speed)
+            df["filling_degree"] = df["level"] / kwargs["capacity"]
+            compute_function = scipy.interpolate.interp1d(df["filling_degree"], df["speed"])
             kwargs["compute_v"] = compute_function
             v_empty = compute_function(0)
             v_full = compute_function(1)

--- a/tests/configs/conditional_activity.json
+++ b/tests/configs/conditional_activity.json
@@ -71,7 +71,7 @@
                         "speed": 5
                     },
                     {
-                        "level": 3,
+                        "level": 3000,
                         "speed": 1
                     }
                 ],

--- a/tests/configs/energy_use.json
+++ b/tests/configs/energy_use.json
@@ -71,7 +71,7 @@
                         "speed": 5
                     },
                     {
-                        "level": 3,
+                        "level": 3000,
                         "speed": 1
                     }
                 ],

--- a/tests/configs/mover_properties_load.json
+++ b/tests/configs/mover_properties_load.json
@@ -71,7 +71,7 @@
                         "speed": 5
                     },
                     {
-                        "level": 3,
+                        "level": 2500,
                         "speed": 1
                     }
                 ],

--- a/tests/configs/multiple_single_run_activities.json
+++ b/tests/configs/multiple_single_run_activities.json
@@ -71,7 +71,7 @@
                         "speed": 5
                     },
                     {
-                        "level": 3,
+                        "level": 3000,
                         "speed": 1
                     }
                 ],

--- a/tests/configs/single_run_activity.json
+++ b/tests/configs/single_run_activity.json
@@ -71,7 +71,7 @@
                         "speed": 5
                     },
                     {
-                        "level": 3,
+                        "level": 3000,
                         "speed": 1
                     }
                 ],

--- a/tests/results/conditional_activity_result.json
+++ b/tests/results/conditional_activity_result.json
@@ -45,7 +45,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 91300,
+            "time": 171721,
             "value": 7000
           }
         },
@@ -60,7 +60,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 95138,
+            "time": 175558,
             "value": 4000
           }
         },
@@ -75,7 +75,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 151249,
+            "time": 312090,
             "value": 4000
           }
         },
@@ -90,7 +90,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 155086,
+            "time": 315928,
             "value": 1000
           }
         },
@@ -105,7 +105,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 211198,
+            "time": 452460,
             "value": 1000
           }
         },
@@ -120,7 +120,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 211792,
+            "time": 453054,
             "value": 0
           }
         }
@@ -141,7 +141,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 65347,
+            "time": 145767,
             "value": 0
           }
         },
@@ -156,7 +156,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 69184,
+            "time": 149605,
             "value": 3000
           }
         },
@@ -171,7 +171,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 125295,
+            "time": 286137,
             "value": 3000
           }
         },
@@ -186,7 +186,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 129133,
+            "time": 289974,
             "value": 6000
           }
         },
@@ -201,7 +201,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 185244,
+            "time": 426506,
             "value": 6000
           }
         },
@@ -216,7 +216,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 189082,
+            "time": 430344,
             "value": 9000
           }
         },
@@ -231,7 +231,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 236065,
+            "time": 483212,
             "value": 9000
           }
         },
@@ -246,7 +246,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 238376,
+            "time": 485522,
             "value": 10000
           }
         }
@@ -349,7 +349,7 @@
           },
           "properties": {
             "message": "sailing filled stop",
-            "time": 65347,
+            "time": 145767,
             "value": 3000
           }
         },
@@ -364,7 +364,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 65347,
+            "time": 145767,
             "value": 3000
           }
         },
@@ -379,7 +379,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 69184,
+            "time": 149605,
             "value": 0
           }
         },
@@ -394,7 +394,7 @@
           },
           "properties": {
             "message": "sailing empty start",
-            "time": 69184,
+            "time": 149605,
             "value": 0
           }
         },
@@ -409,7 +409,7 @@
           },
           "properties": {
             "message": "sailing empty stop",
-            "time": 91300,
+            "time": 171721,
             "value": 0
           }
         },
@@ -424,7 +424,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 91300,
+            "time": 171721,
             "value": 0
           }
         },
@@ -439,7 +439,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 95138,
+            "time": 175558,
             "value": 3000
           }
         },
@@ -454,7 +454,7 @@
           },
           "properties": {
             "message": "sailing filled start",
-            "time": 95138,
+            "time": 175558,
             "value": 3000
           }
         },
@@ -469,7 +469,7 @@
           },
           "properties": {
             "message": "sailing filled stop",
-            "time": 125295,
+            "time": 286137,
             "value": 3000
           }
         },
@@ -484,7 +484,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 125295,
+            "time": 286137,
             "value": 3000
           }
         },
@@ -499,7 +499,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 129133,
+            "time": 289974,
             "value": 0
           }
         },
@@ -514,7 +514,7 @@
           },
           "properties": {
             "message": "sailing empty start",
-            "time": 129133,
+            "time": 289974,
             "value": 0
           }
         },
@@ -529,7 +529,7 @@
           },
           "properties": {
             "message": "sailing empty stop",
-            "time": 151249,
+            "time": 312090,
             "value": 0
           }
         },
@@ -544,7 +544,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 151249,
+            "time": 312090,
             "value": 0
           }
         },
@@ -559,7 +559,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 155086,
+            "time": 315928,
             "value": 3000
           }
         },
@@ -574,7 +574,7 @@
           },
           "properties": {
             "message": "sailing filled start",
-            "time": 155086,
+            "time": 315928,
             "value": 3000
           }
         },
@@ -589,7 +589,7 @@
           },
           "properties": {
             "message": "sailing filled stop",
-            "time": 185244,
+            "time": 426506,
             "value": 3000
           }
         },
@@ -604,7 +604,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 185244,
+            "time": 426506,
             "value": 3000
           }
         },
@@ -619,7 +619,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 189082,
+            "time": 430344,
             "value": 0
           }
         },
@@ -634,7 +634,7 @@
           },
           "properties": {
             "message": "sailing empty start",
-            "time": 189082,
+            "time": 430344,
             "value": 0
           }
         },
@@ -649,7 +649,7 @@
           },
           "properties": {
             "message": "sailing empty stop",
-            "time": 211198,
+            "time": 452460,
             "value": 0
           }
         },
@@ -664,7 +664,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 211198,
+            "time": 452460,
             "value": 0
           }
         },
@@ -679,7 +679,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 211792,
+            "time": 453054,
             "value": 1000
           }
         },
@@ -694,7 +694,7 @@
           },
           "properties": {
             "message": "sailing filled start",
-            "time": 211792,
+            "time": 453054,
             "value": 1000
           }
         },
@@ -709,7 +709,7 @@
           },
           "properties": {
             "message": "sailing filled stop",
-            "time": 236065,
+            "time": 483212,
             "value": 1000
           }
         },
@@ -724,7 +724,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 236065,
+            "time": 483212,
             "value": 1000
           }
         },
@@ -739,7 +739,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 238376,
+            "time": 485522,
             "value": 0
           }
         }
@@ -792,7 +792,7 @@
           },
           "properties": {
             "message": "transporting stop",
-            "time": 69184,
+            "time": 149605,
             "value": 3000
           }
         },
@@ -807,7 +807,7 @@
           },
           "properties": {
             "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 69184,
+            "time": 149605,
             "value": -1
           }
         },
@@ -822,7 +822,7 @@
           },
           "properties": {
             "message": "started single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 69184,
+            "time": 149605,
             "value": -1
           }
         },
@@ -837,7 +837,7 @@
           },
           "properties": {
             "message": "transporting start",
-            "time": 69184,
+            "time": 149605,
             "value": 3000
           }
         },
@@ -852,7 +852,7 @@
           },
           "properties": {
             "message": "transporting stop",
-            "time": 129133,
+            "time": 289974,
             "value": 3000
           }
         },
@@ -867,7 +867,7 @@
           },
           "properties": {
             "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 129133,
+            "time": 289974,
             "value": -1
           }
         },
@@ -882,7 +882,7 @@
           },
           "properties": {
             "message": "started single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 129133,
+            "time": 289974,
             "value": -1
           }
         },
@@ -897,7 +897,7 @@
           },
           "properties": {
             "message": "transporting start",
-            "time": 129133,
+            "time": 289974,
             "value": 3000
           }
         },
@@ -912,7 +912,7 @@
           },
           "properties": {
             "message": "transporting stop",
-            "time": 189082,
+            "time": 430344,
             "value": 3000
           }
         },
@@ -927,7 +927,7 @@
           },
           "properties": {
             "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 189082,
+            "time": 430344,
             "value": -1
           }
         },
@@ -942,7 +942,7 @@
           },
           "properties": {
             "message": "started single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 189082,
+            "time": 430344,
             "value": -1
           }
         },
@@ -957,7 +957,7 @@
           },
           "properties": {
             "message": "transporting start",
-            "time": 189082,
+            "time": 430344,
             "value": 1000
           }
         },
@@ -972,7 +972,7 @@
           },
           "properties": {
             "message": "transporting stop",
-            "time": 238376,
+            "time": 485522,
             "value": 1000
           }
         },
@@ -987,12 +987,12 @@
           },
           "properties": {
             "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 238376,
+            "time": 485522,
             "value": -1
           }
         }
       ]
     }
   ],
-  "completionTime": 238376.28085478942
+  "completionTime": 485522.77668242954
 }

--- a/tests/results/energy_use_result.json
+++ b/tests/results/energy_use_result.json
@@ -45,7 +45,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 112206,
+            "time": 212732,
             "value": 7000
           }
         },
@@ -60,7 +60,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 116044,
+            "time": 216570,
             "value": 4000
           }
         },
@@ -75,7 +75,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 185223,
+            "time": 386275,
             "value": 4000
           }
         },
@@ -90,7 +90,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 189061,
+            "time": 390113,
             "value": 1000
           }
         },
@@ -105,7 +105,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 258241,
+            "time": 559818,
             "value": 1000
           }
         },
@@ -120,7 +120,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 258835,
+            "time": 560413,
             "value": 0
           }
         }
@@ -141,7 +141,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 80724,
+            "time": 181250,
             "value": 0
           }
         },
@@ -156,7 +156,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 84562,
+            "time": 185088,
             "value": 3000
           }
         },
@@ -171,7 +171,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 153741,
+            "time": 354793,
             "value": 3000
           }
         },
@@ -186,7 +186,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 157579,
+            "time": 358631,
             "value": 6000
           }
         },
@@ -201,7 +201,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 226758,
+            "time": 528336,
             "value": 6000
           }
         },
@@ -216,7 +216,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 230596,
+            "time": 532174,
             "value": 9000
           }
         },
@@ -231,7 +231,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 289177,
+            "time": 598110,
             "value": 9000
           }
         },
@@ -246,7 +246,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 291487,
+            "time": 600420,
             "value": 10000
           }
         }
@@ -379,8 +379,8 @@
           },
           "properties": {
             "message": "Energy use sailing filled",
-            "time": 80724,
-            "value": 57653.67295577117
+            "time": 181250,
+            "value": 211396.8008378276
           }
         },
         {
@@ -394,7 +394,7 @@
           },
           "properties": {
             "message": "sailing filled stop",
-            "time": 80724,
+            "time": 181250,
             "value": 3000
           }
         },
@@ -409,7 +409,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 80724,
+            "time": 181250,
             "value": 3000
           }
         },
@@ -424,7 +424,7 @@
           },
           "properties": {
             "message": "Energy use unloading",
-            "time": 84562,
+            "time": 185088,
             "value": 7750.970468129518
           }
         },
@@ -439,7 +439,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 84562,
+            "time": 185088,
             "value": 0
           }
         },
@@ -454,7 +454,7 @@
           },
           "properties": {
             "message": "sailing empty start",
-            "time": 84562,
+            "time": 185088,
             "value": 0
           }
         },
@@ -469,7 +469,7 @@
           },
           "properties": {
             "message": "Energy use sailing empty",
-            "time": 112206,
+            "time": 212732,
             "value": 42279.36016756553
           }
         },
@@ -484,7 +484,7 @@
           },
           "properties": {
             "message": "sailing empty stop",
-            "time": 112206,
+            "time": 212732,
             "value": 0
           }
         },
@@ -499,7 +499,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 112206,
+            "time": 212732,
             "value": 0
           }
         },
@@ -514,7 +514,7 @@
           },
           "properties": {
             "message": "Energy use loading",
-            "time": 116044,
+            "time": 216570,
             "value": 9856.343411955098
           }
         },
@@ -529,7 +529,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 116044,
+            "time": 216570,
             "value": 3000
           }
         },
@@ -544,7 +544,7 @@
           },
           "properties": {
             "message": "sailing filled start",
-            "time": 116044,
+            "time": 216570,
             "value": 3000
           }
         },
@@ -559,8 +559,8 @@
           },
           "properties": {
             "message": "Energy use sailing filled",
-            "time": 153741,
-            "value": 57653.67295577117
+            "time": 354793,
+            "value": 211396.8008378276
           }
         },
         {
@@ -574,7 +574,7 @@
           },
           "properties": {
             "message": "sailing filled stop",
-            "time": 153741,
+            "time": 354793,
             "value": 3000
           }
         },
@@ -589,7 +589,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 153741,
+            "time": 354793,
             "value": 3000
           }
         },
@@ -604,7 +604,7 @@
           },
           "properties": {
             "message": "Energy use unloading",
-            "time": 157579,
+            "time": 358631,
             "value": 7750.970468129518
           }
         },
@@ -619,7 +619,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 157579,
+            "time": 358631,
             "value": 0
           }
         },
@@ -634,7 +634,7 @@
           },
           "properties": {
             "message": "sailing empty start",
-            "time": 157579,
+            "time": 358631,
             "value": 0
           }
         },
@@ -649,7 +649,7 @@
           },
           "properties": {
             "message": "Energy use sailing empty",
-            "time": 185223,
+            "time": 386275,
             "value": 42279.36016756553
           }
         },
@@ -664,7 +664,7 @@
           },
           "properties": {
             "message": "sailing empty stop",
-            "time": 185223,
+            "time": 386275,
             "value": 0
           }
         },
@@ -679,7 +679,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 185223,
+            "time": 386275,
             "value": 0
           }
         },
@@ -694,7 +694,7 @@
           },
           "properties": {
             "message": "Energy use loading",
-            "time": 189061,
+            "time": 390113,
             "value": 9856.343411955098
           }
         },
@@ -709,7 +709,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 189061,
+            "time": 390113,
             "value": 3000
           }
         },
@@ -724,7 +724,7 @@
           },
           "properties": {
             "message": "sailing filled start",
-            "time": 189061,
+            "time": 390113,
             "value": 3000
           }
         },
@@ -739,8 +739,8 @@
           },
           "properties": {
             "message": "Energy use sailing filled",
-            "time": 226758,
-            "value": 57653.67295577117
+            "time": 528336,
+            "value": 211396.8008378276
           }
         },
         {
@@ -754,7 +754,7 @@
           },
           "properties": {
             "message": "sailing filled stop",
-            "time": 226758,
+            "time": 528336,
             "value": 3000
           }
         },
@@ -769,7 +769,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 226758,
+            "time": 528336,
             "value": 3000
           }
         },
@@ -784,7 +784,7 @@
           },
           "properties": {
             "message": "Energy use unloading",
-            "time": 230596,
+            "time": 532174,
             "value": 7750.970468129518
           }
         },
@@ -799,7 +799,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 230596,
+            "time": 532174,
             "value": 0
           }
         },
@@ -814,7 +814,7 @@
           },
           "properties": {
             "message": "sailing empty start",
-            "time": 230596,
+            "time": 532174,
             "value": 0
           }
         },
@@ -829,7 +829,7 @@
           },
           "properties": {
             "message": "Energy use sailing empty",
-            "time": 258241,
+            "time": 559818,
             "value": 42279.36016756553
           }
         },
@@ -844,7 +844,7 @@
           },
           "properties": {
             "message": "sailing empty stop",
-            "time": 258241,
+            "time": 559818,
             "value": 0
           }
         },
@@ -859,7 +859,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 258241,
+            "time": 559818,
             "value": 0
           }
         },
@@ -874,7 +874,7 @@
           },
           "properties": {
             "message": "Energy use loading",
-            "time": 258835,
+            "time": 560413,
             "value": 1526.7669128044072
           }
         },
@@ -889,7 +889,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 258835,
+            "time": 560413,
             "value": 1000
           }
         },
@@ -904,7 +904,7 @@
           },
           "properties": {
             "message": "sailing filled start",
-            "time": 258835,
+            "time": 560413,
             "value": 1000
           }
         },
@@ -919,8 +919,8 @@
           },
           "properties": {
             "message": "Energy use sailing filled",
-            "time": 289177,
-            "value": 52689.42279052441
+            "time": 598110,
+            "value": 911744.8069394885
           }
         },
         {
@@ -934,7 +934,7 @@
           },
           "properties": {
             "message": "sailing filled stop",
-            "time": 289177,
+            "time": 598110,
             "value": 1000
           }
         },
@@ -949,7 +949,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 289177,
+            "time": 598110,
             "value": 1000
           }
         },
@@ -964,7 +964,7 @@
           },
           "properties": {
             "message": "Energy use unloading",
-            "time": 291487,
+            "time": 600420,
             "value": 4666.5492128253345
           }
         },
@@ -979,7 +979,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 291487,
+            "time": 600420,
             "value": 0
           }
         }
@@ -1032,7 +1032,7 @@
           },
           "properties": {
             "message": "transporting stop",
-            "time": 84562,
+            "time": 185088,
             "value": 3000
           }
         },
@@ -1047,7 +1047,7 @@
           },
           "properties": {
             "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 84562,
+            "time": 185088,
             "value": -1
           }
         },
@@ -1062,7 +1062,7 @@
           },
           "properties": {
             "message": "started single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 84562,
+            "time": 185088,
             "value": -1
           }
         },
@@ -1077,7 +1077,7 @@
           },
           "properties": {
             "message": "transporting start",
-            "time": 84562,
+            "time": 185088,
             "value": 3000
           }
         },
@@ -1092,7 +1092,7 @@
           },
           "properties": {
             "message": "transporting stop",
-            "time": 157579,
+            "time": 358631,
             "value": 3000
           }
         },
@@ -1107,7 +1107,7 @@
           },
           "properties": {
             "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 157579,
+            "time": 358631,
             "value": -1
           }
         },
@@ -1122,7 +1122,7 @@
           },
           "properties": {
             "message": "started single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 157579,
+            "time": 358631,
             "value": -1
           }
         },
@@ -1137,7 +1137,7 @@
           },
           "properties": {
             "message": "transporting start",
-            "time": 157579,
+            "time": 358631,
             "value": 3000
           }
         },
@@ -1152,7 +1152,7 @@
           },
           "properties": {
             "message": "transporting stop",
-            "time": 230596,
+            "time": 532174,
             "value": 3000
           }
         },
@@ -1167,7 +1167,7 @@
           },
           "properties": {
             "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 230596,
+            "time": 532174,
             "value": -1
           }
         },
@@ -1182,7 +1182,7 @@
           },
           "properties": {
             "message": "started single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 230596,
+            "time": 532174,
             "value": -1
           }
         },
@@ -1197,7 +1197,7 @@
           },
           "properties": {
             "message": "transporting start",
-            "time": 230596,
+            "time": 532174,
             "value": 1000
           }
         },
@@ -1212,7 +1212,7 @@
           },
           "properties": {
             "message": "transporting stop",
-            "time": 291487,
+            "time": 600420,
             "value": 1000
           }
         },
@@ -1227,12 +1227,12 @@
           },
           "properties": {
             "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 291487,
+            "time": 600420,
             "value": -1
           }
         }
       ]
     }
   ],
-  "completionTime": 291487.6511255606
+  "completionTime": 600420.7709101104
 }

--- a/tests/results/mover_properties_load_result.json
+++ b/tests/results/mover_properties_load_result.json
@@ -45,7 +45,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 86271,
+            "time": 119590,
             "value": 8000
           }
         },
@@ -60,7 +60,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 88039,
+            "time": 121358,
             "value": 6000
           }
         },
@@ -75,7 +75,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 141190,
+            "time": 207828,
             "value": 6000
           }
         },
@@ -90,7 +90,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 142958,
+            "time": 209596,
             "value": 4000
           }
         },
@@ -105,7 +105,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 196109,
+            "time": 296067,
             "value": 4000
           }
         },
@@ -120,7 +120,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 197877,
+            "time": 297835,
             "value": 2000
           }
         },
@@ -135,7 +135,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 251028,
+            "time": 384306,
             "value": 2000
           }
         },
@@ -150,7 +150,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 252796,
+            "time": 386074,
             "value": 0
           }
         }
@@ -171,7 +171,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 61232,
+            "time": 94552,
             "value": 0
           }
         },
@@ -186,7 +186,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 64155,
+            "time": 97474,
             "value": 2000
           }
         },
@@ -201,7 +201,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 116152,
+            "time": 182790,
             "value": 2000
           }
         },
@@ -216,7 +216,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 119074,
+            "time": 185713,
             "value": 4000
           }
         },
@@ -231,7 +231,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 171071,
+            "time": 271029,
             "value": 4000
           }
         },
@@ -246,7 +246,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 173993,
+            "time": 273951,
             "value": 6000
           }
         },
@@ -261,7 +261,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 225990,
+            "time": 359268,
             "value": 6000
           }
         },
@@ -276,7 +276,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 228913,
+            "time": 362190,
             "value": 8000
           }
         },
@@ -291,7 +291,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 280910,
+            "time": 447506,
             "value": 8000
           }
         },
@@ -306,7 +306,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 283832,
+            "time": 450429,
             "value": 10000
           }
         }
@@ -409,7 +409,7 @@
           },
           "properties": {
             "message": "sailing filled stop",
-            "time": 61232,
+            "time": 94552,
             "value": 2000
           }
         },
@@ -424,7 +424,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 61232,
+            "time": 94552,
             "value": 2000
           }
         },
@@ -439,7 +439,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 64155,
+            "time": 97474,
             "value": 0
           }
         },
@@ -454,7 +454,7 @@
           },
           "properties": {
             "message": "sailing empty start",
-            "time": 64155,
+            "time": 97474,
             "value": 0
           }
         },
@@ -469,7 +469,7 @@
           },
           "properties": {
             "message": "sailing empty stop",
-            "time": 86271,
+            "time": 119590,
             "value": 0
           }
         },
@@ -484,7 +484,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 86271,
+            "time": 119590,
             "value": 0
           }
         },
@@ -499,7 +499,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 88039,
+            "time": 121358,
             "value": 2000
           }
         },
@@ -514,7 +514,7 @@
           },
           "properties": {
             "message": "sailing filled start",
-            "time": 88039,
+            "time": 121358,
             "value": 2000
           }
         },
@@ -529,7 +529,7 @@
           },
           "properties": {
             "message": "sailing filled stop",
-            "time": 116152,
+            "time": 182790,
             "value": 2000
           }
         },
@@ -544,7 +544,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 116152,
+            "time": 182790,
             "value": 2000
           }
         },
@@ -559,7 +559,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 119074,
+            "time": 185713,
             "value": 0
           }
         },
@@ -574,7 +574,7 @@
           },
           "properties": {
             "message": "sailing empty start",
-            "time": 119074,
+            "time": 185713,
             "value": 0
           }
         },
@@ -589,7 +589,7 @@
           },
           "properties": {
             "message": "sailing empty stop",
-            "time": 141190,
+            "time": 207828,
             "value": 0
           }
         },
@@ -604,7 +604,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 141190,
+            "time": 207828,
             "value": 0
           }
         },
@@ -619,7 +619,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 142958,
+            "time": 209596,
             "value": 2000
           }
         },
@@ -634,7 +634,7 @@
           },
           "properties": {
             "message": "sailing filled start",
-            "time": 142958,
+            "time": 209596,
             "value": 2000
           }
         },
@@ -649,7 +649,7 @@
           },
           "properties": {
             "message": "sailing filled stop",
-            "time": 171071,
+            "time": 271029,
             "value": 2000
           }
         },
@@ -664,7 +664,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 171071,
+            "time": 271029,
             "value": 2000
           }
         },
@@ -679,7 +679,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 173993,
+            "time": 273951,
             "value": 0
           }
         },
@@ -694,7 +694,7 @@
           },
           "properties": {
             "message": "sailing empty start",
-            "time": 173993,
+            "time": 273951,
             "value": 0
           }
         },
@@ -709,7 +709,7 @@
           },
           "properties": {
             "message": "sailing empty stop",
-            "time": 196109,
+            "time": 296067,
             "value": 0
           }
         },
@@ -724,7 +724,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 196109,
+            "time": 296067,
             "value": 0
           }
         },
@@ -739,7 +739,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 197877,
+            "time": 297835,
             "value": 2000
           }
         },
@@ -754,7 +754,7 @@
           },
           "properties": {
             "message": "sailing filled start",
-            "time": 197877,
+            "time": 297835,
             "value": 2000
           }
         },
@@ -769,7 +769,7 @@
           },
           "properties": {
             "message": "sailing filled stop",
-            "time": 225990,
+            "time": 359268,
             "value": 2000
           }
         },
@@ -784,7 +784,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 225990,
+            "time": 359268,
             "value": 2000
           }
         },
@@ -799,7 +799,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 228913,
+            "time": 362190,
             "value": 0
           }
         },
@@ -814,7 +814,7 @@
           },
           "properties": {
             "message": "sailing empty start",
-            "time": 228913,
+            "time": 362190,
             "value": 0
           }
         },
@@ -829,7 +829,7 @@
           },
           "properties": {
             "message": "sailing empty stop",
-            "time": 251028,
+            "time": 384306,
             "value": 0
           }
         },
@@ -844,7 +844,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 251028,
+            "time": 384306,
             "value": 0
           }
         },
@@ -859,7 +859,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 252796,
+            "time": 386074,
             "value": 2000
           }
         },
@@ -874,7 +874,7 @@
           },
           "properties": {
             "message": "sailing filled start",
-            "time": 252796,
+            "time": 386074,
             "value": 2000
           }
         },
@@ -889,7 +889,7 @@
           },
           "properties": {
             "message": "sailing filled stop",
-            "time": 280910,
+            "time": 447506,
             "value": 2000
           }
         },
@@ -904,7 +904,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 280910,
+            "time": 447506,
             "value": 2000
           }
         },
@@ -919,7 +919,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 283832,
+            "time": 450429,
             "value": 0
           }
         }
@@ -972,7 +972,7 @@
           },
           "properties": {
             "message": "transporting stop",
-            "time": 64155,
+            "time": 97474,
             "value": 2000
           }
         },
@@ -987,7 +987,7 @@
           },
           "properties": {
             "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 64155,
+            "time": 97474,
             "value": -1
           }
         },
@@ -1002,7 +1002,7 @@
           },
           "properties": {
             "message": "started single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 64155,
+            "time": 97474,
             "value": -1
           }
         },
@@ -1017,7 +1017,7 @@
           },
           "properties": {
             "message": "transporting start",
-            "time": 64155,
+            "time": 97474,
             "value": 2000
           }
         },
@@ -1032,7 +1032,7 @@
           },
           "properties": {
             "message": "transporting stop",
-            "time": 119074,
+            "time": 185713,
             "value": 2000
           }
         },
@@ -1047,7 +1047,7 @@
           },
           "properties": {
             "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 119074,
+            "time": 185713,
             "value": -1
           }
         },
@@ -1062,7 +1062,7 @@
           },
           "properties": {
             "message": "started single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 119074,
+            "time": 185713,
             "value": -1
           }
         },
@@ -1077,7 +1077,7 @@
           },
           "properties": {
             "message": "transporting start",
-            "time": 119074,
+            "time": 185713,
             "value": 2000
           }
         },
@@ -1092,7 +1092,7 @@
           },
           "properties": {
             "message": "transporting stop",
-            "time": 173993,
+            "time": 273951,
             "value": 2000
           }
         },
@@ -1107,7 +1107,7 @@
           },
           "properties": {
             "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 173993,
+            "time": 273951,
             "value": -1
           }
         },
@@ -1122,7 +1122,7 @@
           },
           "properties": {
             "message": "started single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 173993,
+            "time": 273951,
             "value": -1
           }
         },
@@ -1137,7 +1137,7 @@
           },
           "properties": {
             "message": "transporting start",
-            "time": 173993,
+            "time": 273951,
             "value": 2000
           }
         },
@@ -1152,7 +1152,7 @@
           },
           "properties": {
             "message": "transporting stop",
-            "time": 228913,
+            "time": 362190,
             "value": 2000
           }
         },
@@ -1167,7 +1167,7 @@
           },
           "properties": {
             "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 228913,
+            "time": 362190,
             "value": -1
           }
         },
@@ -1182,7 +1182,7 @@
           },
           "properties": {
             "message": "started single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 228913,
+            "time": 362190,
             "value": -1
           }
         },
@@ -1197,7 +1197,7 @@
           },
           "properties": {
             "message": "transporting start",
-            "time": 228913,
+            "time": 362190,
             "value": 2000
           }
         },
@@ -1212,7 +1212,7 @@
           },
           "properties": {
             "message": "transporting stop",
-            "time": 283832,
+            "time": 450429,
             "value": 2000
           }
         },
@@ -1227,12 +1227,12 @@
           },
           "properties": {
             "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 283832,
+            "time": 450429,
             "value": -1
           }
         }
       ]
     }
   ],
-  "completionTime": 283832.4805096547
+  "completionTime": 450429.0034198059
 }

--- a/tests/results/multiple_single_run_activities_result.json
+++ b/tests/results/multiple_single_run_activities_result.json
@@ -45,7 +45,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 91300,
+            "time": 171721,
             "value": 2000
           }
         },
@@ -60,7 +60,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 92827,
+            "time": 173248,
             "value": 0
           }
         }
@@ -81,7 +81,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 65347,
+            "time": 145767,
             "value": 0
           }
         },
@@ -96,7 +96,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 69184,
+            "time": 149605,
             "value": 3000
           }
         },
@@ -111,7 +111,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 119725,
+            "time": 220639,
             "value": 3000
           }
         },
@@ -126,7 +126,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 122968,
+            "time": 223882,
             "value": 5000
           }
         }
@@ -229,7 +229,7 @@
           },
           "properties": {
             "message": "sailing filled stop",
-            "time": 65347,
+            "time": 145767,
             "value": 3000
           }
         },
@@ -244,7 +244,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 65347,
+            "time": 145767,
             "value": 3000
           }
         },
@@ -259,7 +259,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 69184,
+            "time": 149605,
             "value": 0
           }
         },
@@ -274,7 +274,7 @@
           },
           "properties": {
             "message": "sailing empty start",
-            "time": 69184,
+            "time": 149605,
             "value": 0
           }
         },
@@ -289,7 +289,7 @@
           },
           "properties": {
             "message": "sailing empty stop",
-            "time": 91300,
+            "time": 171721,
             "value": 0
           }
         },
@@ -304,7 +304,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 91300,
+            "time": 171721,
             "value": 0
           }
         },
@@ -319,7 +319,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 92827,
+            "time": 173248,
             "value": 2000
           }
         },
@@ -334,7 +334,7 @@
           },
           "properties": {
             "message": "sailing filled start",
-            "time": 92827,
+            "time": 173248,
             "value": 2000
           }
         },
@@ -349,7 +349,7 @@
           },
           "properties": {
             "message": "sailing filled stop",
-            "time": 119725,
+            "time": 220639,
             "value": 2000
           }
         },
@@ -364,7 +364,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 119725,
+            "time": 220639,
             "value": 2000
           }
         },
@@ -379,7 +379,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 122968,
+            "time": 223882,
             "value": 0
           }
         }
@@ -432,7 +432,7 @@
           },
           "properties": {
             "message": "transporting stop",
-            "time": 69184,
+            "time": 149605,
             "value": 3000
           }
         },
@@ -447,7 +447,7 @@
           },
           "properties": {
             "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 69184,
+            "time": 149605,
             "value": -1
           }
         }
@@ -498,7 +498,7 @@
           },
           "properties": {
             "message": "transporting stop",
-            "time": 122968,
+            "time": 223882,
             "value": 2000
           }
         },
@@ -513,7 +513,7 @@
           },
           "properties": {
             "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 122968,
+            "time": 223882,
             "value": -1
           }
         }
@@ -556,5 +556,5 @@
       ]
     }
   ],
-  "completionTime": 122968.35116282044
+  "completionTime": 223882.33832048738
 }

--- a/tests/results/single_run_activity_result.json
+++ b/tests/results/single_run_activity_result.json
@@ -51,7 +51,7 @@
           },
           "properties": {
             "message": "loading start",
-            "time": 65347,
+            "time": 145767,
             "value": 0
           }
         },
@@ -66,7 +66,7 @@
           },
           "properties": {
             "message": "loading stop",
-            "time": 69184,
+            "time": 149605,
             "value": 3000
           }
         }
@@ -169,7 +169,7 @@
           },
           "properties": {
             "message": "sailing filled stop",
-            "time": 65347,
+            "time": 145767,
             "value": 3000
           }
         },
@@ -184,7 +184,7 @@
           },
           "properties": {
             "message": "unloading start",
-            "time": 65347,
+            "time": 145767,
             "value": 3000
           }
         },
@@ -199,7 +199,7 @@
           },
           "properties": {
             "message": "unloading stop",
-            "time": 69184,
+            "time": 149605,
             "value": 0
           }
         }
@@ -252,7 +252,7 @@
           },
           "properties": {
             "message": "transporting stop",
-            "time": 69184,
+            "time": 149605,
             "value": 3000
           }
         },
@@ -267,12 +267,12 @@
           },
           "properties": {
             "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
-            "time": 69184,
+            "time": 149605,
             "value": -1
           }
         }
       ]
     }
   ],
-  "completionTime": 69184.86906023216
+  "completionTime": 149605.554210496
 }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -90,4 +90,4 @@ def test_energy_use():
         if "Energy use" in log_entry["properties"]["message"]:
             energy_use += log_entry["properties"]["value"]
 
-    np.testing.assert_almost_equal(energy_use, 471440.2025916437)
+    np.testing.assert_almost_equal(energy_use, 1791724.970386777)


### PR DESCRIPTION
The compute_v is given a filling degree instead of a level, compute
the corresponding filling_degree for each of the levels given in the
configuration and use this to construct compute_v.