### PR TITLE
Add support for depth restrictions to simulation

### DIFF
--- a/tests/configs/depth_restriction.json
+++ b/tests/configs/depth_restriction.json
@@ -1,0 +1,531 @@
+{
+    "level": 3,
+    "initialTime": 0,
+    "sites": [
+        {
+            "id": "afsluitdijk",
+            "name": "Afsluitdijk",
+            "type": [
+                "Locatable", "HasResource", "HasContainer", "HasWeather"
+            ],
+            "properties": {
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                        53,
+                        4
+                    ]
+                },
+                "capacity": 10000,
+                "level": 10000,
+                "weather": [
+                    {
+                      "time": 0,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 22200,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 44400,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 66600,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 88800,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 111000,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 133200,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 155400,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 177600,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 199800,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 222000,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 244200,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 266400,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 288600,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 310800,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 333000,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 355200,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 377400,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 399600,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 421800,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 444000,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 466200,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 488400,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 510600,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 532800,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 555000,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 577200,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 599400,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 621600,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 643800,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 666000,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 688200,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 710400,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 732600,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 754800,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 777000,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 799200,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 821400,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 843600,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 865800,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 888000,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 910200,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 932400,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 954600,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 976800,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 999000,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 1021200,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 1043400,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 1065600,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 1087800,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 1110000,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 1132200,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 1154400,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 1176600,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 1198800,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 1221000,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 1243200,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 1265400,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 1287600,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 1309800,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 1332000,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 1354200,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 1376400,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 1398600,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 1420800,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 1443000,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 1465200,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 1487400,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 1509600,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 1531800,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 1554000,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 1576200,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 1598400,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 1620600,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 1642800,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 1665000,
+                      "tide": -1,
+                      "hs": 1
+                    },
+                    {
+                      "time": 1687200,
+                      "tide": 1,
+                      "hs": 0.5
+                    },
+                    {
+                      "time": 1709400,
+                      "tide": -1,
+                      "hs": 1
+                    }
+                  ],
+                "bed": -7
+            }
+        },
+        {
+            "id": "maasvlakte",
+            "name": "Maasvlakte",
+            "type": [
+                "Locatable", "HasResource", "HasContainer"
+            ],
+            "properties": {
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                        53,
+                        3
+                    ]
+                },
+                "capacity": 50000,
+                "level": 0
+
+            }
+        },
+        {
+            "id": "home",
+            "name": "Home",
+            "type": [
+                "Locatable"
+            ],
+            "properties": {
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                        52,
+                        3
+                    ]
+                }
+            }
+        }
+    ],
+    "equipment": [
+        {
+            "id": "hopper",
+            "name": "Boaty McBoatstone",
+            "type": [
+                "ContainerDependentMovable", "HasResource", "Processor", "HasDepthRestriction"
+            ],
+            "properties": {
+                "speed": [
+                    {
+                        "level": 0,
+                        "speed": 5
+                    },
+                    {
+                        "level": 3000,
+                        "speed": 1
+                    }
+                ],
+                "location": "home",
+                "capacity": 3000,
+                "loadingRate": [
+                    {
+                        "level": 0,
+                        "rate": 2
+                    },
+                    {
+                        "level": 3000,
+                        "rate": 0.2
+                    }
+                ],
+                "unloadingRate": [
+                    {
+                        "level": 3000,
+                        "rate": 2
+                    },
+                    {
+                        "level": 0,
+                        "rate": 0.2
+                    }
+                ],
+                "draught": [
+                    {
+                        "level": 0,
+                        "draught": 4.0
+                    },
+                    {
+                        "level": 3000,
+                        "draught": 7.0
+                    }
+                ],
+                "waves": [0.5, 1],
+                "ukc": [0.75, 1]
+            }
+        }
+    ],
+    "activities": [
+        {
+            "id": "conditional_dredging",
+            "type": "conditional",
+            "condition": {
+                "operator": "is_filled",
+                "operand": "afsluitdijk"
+            },
+            "activities": [
+                {
+                    "id": "dredge_run",
+                    "type": "single_run",
+                    "origin": "afsluitdijk",
+                    "destination": "maasvlakte",
+                    "loader": "hopper",
+                    "mover": "hopper",
+                    "unloader": "hopper",
+                    "moverProperties": {
+                        "load": 0.8
+                    }
+                }
+            ]
+        }
+    ]
+}

--- a/tests/results/depth_restriction_result.json
+++ b/tests/results/depth_restriction_result.json
@@ -1,0 +1,1283 @@
+{
+  "sites": [
+    {
+      "type": "FeatureCollection",
+      "id": "afsluitdijk",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "unloading start",
+            "time": 37800,
+            "value": 10000
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "unloading stop",
+            "time": 39921,
+            "value": 7600
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "unloading start",
+            "time": 126976,
+            "value": 7600
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "unloading stop",
+            "time": 129098,
+            "value": 5200
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "unloading start",
+            "time": 216153,
+            "value": 5200
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "unloading stop",
+            "time": 218274,
+            "value": 2800
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "unloading start",
+            "time": 305329,
+            "value": 2800
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "unloading stop",
+            "time": 307451,
+            "value": 400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "unloading start",
+            "time": 394506,
+            "value": 400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "unloading stop",
+            "time": 394719,
+            "value": 0
+          }
+        }
+      ]
+    },
+    {
+      "type": "FeatureCollection",
+      "id": "maasvlakte",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "loading start",
+            "time": 101354,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "loading stop",
+            "time": 104860,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "loading start",
+            "time": 190530,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "loading stop",
+            "time": 194037,
+            "value": 4800
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "loading start",
+            "time": 279707,
+            "value": 4800
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "loading stop",
+            "time": 283214,
+            "value": 7200
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "loading start",
+            "time": 368884,
+            "value": 7200
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "loading stop",
+            "time": 372390,
+            "value": 9600
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "loading start",
+            "time": 419476,
+            "value": 9600
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "loading stop",
+            "time": 420790,
+            "value": 10000
+          }
+        }
+      ]
+    },
+    {
+      "type": "FeatureCollection",
+      "id": "home",
+      "features": []
+    }
+  ],
+  "equipment": [
+    {
+      "type": "FeatureCollection",
+      "id": "hopper",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              52,
+              3
+            ]
+          },
+          "properties": {
+            "message": "sailing empty start",
+            "time": 0,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "sailing empty stop",
+            "time": 31351,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "waiting for tide start",
+            "time": 31351,
+            "value": 6448.171514
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "waiting for tide stop",
+            "time": 37800,
+            "value": 6448.171514
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "loading start",
+            "time": 37800,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "loading stop",
+            "time": 39921,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "sailing filled start",
+            "time": 39921,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "sailing filled stop",
+            "time": 101354,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "unloading start",
+            "time": 101354,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "unloading stop",
+            "time": 104860,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "sailing empty start",
+            "time": 104860,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "sailing empty stop",
+            "time": 126976,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "loading start",
+            "time": 126976,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "loading stop",
+            "time": 129098,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "sailing filled start",
+            "time": 129098,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "sailing filled stop",
+            "time": 190530,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "unloading start",
+            "time": 190530,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "unloading stop",
+            "time": 194037,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "sailing empty start",
+            "time": 194037,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "sailing empty stop",
+            "time": 216153,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "loading start",
+            "time": 216153,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "loading stop",
+            "time": 218274,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "sailing filled start",
+            "time": 218274,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "sailing filled stop",
+            "time": 279707,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "unloading start",
+            "time": 279707,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "unloading stop",
+            "time": 283214,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "sailing empty start",
+            "time": 283214,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "sailing empty stop",
+            "time": 305329,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "loading start",
+            "time": 305329,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "loading stop",
+            "time": 307451,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "sailing filled start",
+            "time": 307451,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "sailing filled stop",
+            "time": 368884,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "unloading start",
+            "time": 368884,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "unloading stop",
+            "time": 372390,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "sailing empty start",
+            "time": 372390,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "sailing empty stop",
+            "time": 394506,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "No actual allowable draught available - starting anyway",
+            "time": 394506,
+            "value": -1
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "loading start",
+            "time": 394506,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "loading stop",
+            "time": 394719,
+            "value": 400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "sailing filled start",
+            "time": 394719,
+            "value": 400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "sailing filled stop",
+            "time": 419476,
+            "value": 400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "unloading start",
+            "time": 419476,
+            "value": 400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "unloading stop",
+            "time": 420790,
+            "value": 0
+          }
+        }
+      ]
+    }
+  ],
+  "activities": [
+    {
+      "type": "FeatureCollection",
+      "id": "conditional_dredging",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              52,
+              3
+            ]
+          },
+          "properties": {
+            "message": "started single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
+            "time": 0,
+            "value": -1
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              52,
+              3
+            ]
+          },
+          "properties": {
+            "message": "transporting start",
+            "time": 0,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "transporting stop",
+            "time": 104860,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
+            "time": 104860,
+            "value": -1
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "started single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
+            "time": 104860,
+            "value": -1
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "transporting start",
+            "time": 104860,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "transporting stop",
+            "time": 194037,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
+            "time": 194037,
+            "value": -1
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "started single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
+            "time": 194037,
+            "value": -1
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "transporting start",
+            "time": 194037,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "transporting stop",
+            "time": 283214,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
+            "time": 283214,
+            "value": -1
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "started single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
+            "time": 283214,
+            "value": -1
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "transporting start",
+            "time": 283214,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "transporting stop",
+            "time": 372390,
+            "value": 2400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
+            "time": 372390,
+            "value": -1
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "started single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
+            "time": 372390,
+            "value": -1
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "transporting start",
+            "time": 372390,
+            "value": 400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "transporting stop",
+            "time": 420790,
+            "value": 400
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "completed single_run activity loading Boaty McBoatstone at Afsluitdijk with Boaty McBoatstone and transporting to Maasvlakte unloading with Boaty McBoatstone",
+            "time": 420790,
+            "value": -1
+          }
+        }
+      ]
+    }
+  ],
+  "completionTime": 420790.1426745554
+}

--- a/tests/test_depth_limitation.py
+++ b/tests/test_depth_limitation.py
@@ -10,6 +10,7 @@ import logging
 import datetime
 import time
 import numpy as np
+import pandas as pd
 
 from click.testing import CliRunner
 
@@ -41,6 +42,13 @@ def locatable_a(geometry_a):
 @pytest.fixture
 def locatable_b(geometry_b):
     return core.Locatable(geometry_b)
+
+@pytest.fixture
+def weather_data():
+    df = pd.read_csv('tests/test_weather.csv')
+    df.index = df[["Year", "Month", "Day", "Hour"]].apply(lambda s: datetime.datetime(*s), axis=1)
+    df = df.drop(["Year", "Month", "Day", "Hour"], axis=1)
+    return df
 
 # make a location with metocean data
 @pytest.fixture
@@ -88,7 +96,7 @@ def Mover():
             {})
 
 # Test calculating restrictions
-def test_calc_restrictions(env, geometry_a, Mover, Processor, LocationWeather):
+def test_calc_restrictions(env, geometry_a, Mover, Processor, LocationWeather, weather_data):
 
     # Initialize the Mover
     def compute_draught(draught_empty, draught_full):
@@ -122,11 +130,7 @@ def test_calc_restrictions(env, geometry_a, Mover, Processor, LocationWeather):
             "geometry": geometry_a,           # Location
             "capacity": 500_000,              # The capacity of the site
             "level": 500_000,                 # The actual volume of the site
-            "file": "tests/test_weather.csv", # The name of the file with metocean data
-            "year": "Year",                   # The header of the column specifying the year 
-            "month": "Month",                 # The header of the column specifying the month
-            "day": "Day",                     # The header of the column specifying the day
-            "hour": "Hour",                   # The header of the column specifying the hour
+            "dataframe": weather_data,        # The dataframe containing the weather data
             "bed": -7}                        # The level of the seabed with respect to CD 
     
     location = LocationWeather(**data)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -91,3 +91,11 @@ def test_energy_use():
             energy_use += log_entry["properties"]["value"]
 
     np.testing.assert_almost_equal(energy_use, 1791724.970386777)
+
+
+def test_depth_restriction():
+    """Run a simulation including depth restrictions."""
+    run_and_compare_completion_time(
+        config_file='tests/configs/depth_restriction.json',
+        expected_result_file='tests/results/depth_restriction_result.json'
+    )


### PR DESCRIPTION
Changes the init parameters of HasDepthRestriction to a dataframe.
Update the calculation of the waiting time to use the viable ranges for
actual filling degree instead of only checking at intervals of 0.1.