### PR TITLE
Add sequential activity

### DIFF
--- a/tests/configs/sequential_activity.json
+++ b/tests/configs/sequential_activity.json
@@ -1,0 +1,192 @@
+{
+    "level": 3,
+    "initialTime": 0,
+    "sites": [
+        {
+            "id": "origin1",
+            "name": "Origin 1",
+            "type": [
+                "Locatable", "HasResource", "HasContainer"
+            ],
+            "properties": {
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                        53,
+                        4
+                    ]
+                },
+                "capacity": 3000,
+                "level": 3000
+
+            }
+        },
+        {
+            "id": "destination1",
+            "name": "Destination 1",
+            "type": [
+                "Locatable", "HasResource", "HasContainer"
+            ],
+            "properties": {
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                        53,
+                        3
+                    ]
+                },
+                "capacity": 3000,
+                "level": 0
+
+            }
+        },
+        {
+            "id": "origin2",
+            "name": "Origin 2",
+            "type": [
+                "Locatable", "HasResource", "HasContainer"
+            ],
+            "properties": {
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                        53,
+                        4
+                    ]
+                },
+                "capacity": 3000,
+                "level": 3000
+
+            }
+        },
+        {
+            "id": "destination2",
+            "name": "Destination 2",
+            "type": [
+                "Locatable", "HasResource", "HasContainer"
+            ],
+            "properties": {
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [
+                        53,
+                        3
+                    ]
+                },
+                "capacity": 3000,
+                "level": 0
+
+            }
+        }
+    ],
+    "equipment": [
+        {
+            "id": "hopper1",
+            "name": "Hoppy McHopper",
+            "type": [
+                "ContainerDependentMovable", "HasResource", "Processor"
+            ],
+            "properties": {
+                "speed": [
+                    {
+                        "level": 0,
+                        "speed": 5
+                    },
+                    {
+                        "level": 3000,
+                        "speed": 1
+                    }
+                ],
+                "location": "origin1",
+                "capacity": 3000,
+                "loadingRate": [
+                    {
+                        "level": 0,
+                        "rate": 2
+                    },
+                    {
+                        "level": 3000,
+                        "rate": 0.2
+                    }
+                ],
+                "unloadingRate": [
+                    {
+                        "level": 3000,
+                        "rate": 2
+                    },
+                    {
+                        "level": 0,
+                        "rate": 0.2
+                    }
+                ]
+            }
+        },
+        {
+            "id": "hopper2",
+            "name": "Hippety Hoppety",
+            "type": [
+                "ContainerDependentMovable", "HasResource", "Processor"
+            ],
+            "properties": {
+                "speed": [
+                    {
+                        "level": 0,
+                        "speed": 5
+                    },
+                    {
+                        "level": 3000,
+                        "speed": 1
+                    }
+                ],
+                "location": "origin2",
+                "capacity": 3000,
+                "loadingRate": [
+                    {
+                        "level": 0,
+                        "rate": 2
+                    },
+                    {
+                        "level": 3000,
+                        "rate": 0.2
+                    }
+                ],
+                "unloadingRate": [
+                    {
+                        "level": 3000,
+                        "rate": 2
+                    },
+                    {
+                        "level": 0,
+                        "rate": 0.2
+                    }
+                ]
+            }
+        }
+    ],
+    "activities": [
+        {
+            "id": "sequential_dredging",
+            "type": "sequential",
+            "activities": [
+                {
+                    "id": "dredge_run1",
+                    "type": "single_run",
+                    "origin": "origin1",
+                    "destination": "destination1",
+                    "loader": "hopper1",
+                    "mover": "hopper1",
+                    "unloader": "hopper1"
+                },
+                {
+                    "id": "dredge_run2",
+                    "type": "single_run",
+                    "origin": "origin2",
+                    "destination": "destination2",
+                    "loader": "hopper2",
+                    "mover": "hopper2",
+                    "unloader": "hopper2"
+                }
+            ]
+        }
+    ]
+}

--- a/tests/results/sequential_activity_result.json
+++ b/tests/results/sequential_activity_result.json
@@ -1,0 +1,471 @@
+{
+  "sites": [
+    {
+      "type": "FeatureCollection",
+      "id": "origin1",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "unloading start",
+            "time": 0,
+            "value": 3000
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "unloading stop",
+            "time": 3837,
+            "value": 0
+          }
+        }
+      ]
+    },
+    {
+      "type": "FeatureCollection",
+      "id": "destination1",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "loading start",
+            "time": 114416,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "loading stop",
+            "time": 118253,
+            "value": 3000
+          }
+        }
+      ]
+    },
+    {
+      "type": "FeatureCollection",
+      "id": "origin2",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "unloading start",
+            "time": 118253,
+            "value": 3000
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "unloading stop",
+            "time": 122091,
+            "value": 0
+          }
+        }
+      ]
+    },
+    {
+      "type": "FeatureCollection",
+      "id": "destination2",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "loading start",
+            "time": 232669,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "loading stop",
+            "time": 236507,
+            "value": 3000
+          }
+        }
+      ]
+    }
+  ],
+  "equipment": [
+    {
+      "type": "FeatureCollection",
+      "id": "hopper1",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "loading start",
+            "time": 0,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "loading stop",
+            "time": 3837,
+            "value": 3000
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "sailing filled start",
+            "time": 3837,
+            "value": 3000
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "sailing filled stop",
+            "time": 114416,
+            "value": 3000
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "unloading start",
+            "time": 114416,
+            "value": 3000
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "unloading stop",
+            "time": 118253,
+            "value": 0
+          }
+        }
+      ]
+    },
+    {
+      "type": "FeatureCollection",
+      "id": "hopper2",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "loading start",
+            "time": 118253,
+            "value": 0
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "loading stop",
+            "time": 122091,
+            "value": 3000
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "sailing filled start",
+            "time": 122091,
+            "value": 3000
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "sailing filled stop",
+            "time": 232669,
+            "value": 3000
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "unloading start",
+            "time": 232669,
+            "value": 3000
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "unloading stop",
+            "time": 236507,
+            "value": 0
+          }
+        }
+      ]
+    }
+  ],
+  "activities": [
+    {
+      "type": "FeatureCollection",
+      "id": "sequential_dredging",
+      "features": [
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "started single_run activity loading Hoppy McHopper at Origin 1 with Hoppy McHopper and transporting to Destination 1 unloading with Hoppy McHopper",
+            "time": 0,
+            "value": -1
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "transporting start",
+            "time": 0,
+            "value": 3000
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "transporting stop",
+            "time": 118253,
+            "value": 3000
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "completed single_run activity loading Hoppy McHopper at Origin 1 with Hoppy McHopper and transporting to Destination 1 unloading with Hoppy McHopper",
+            "time": 118253,
+            "value": -1
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "started single_run activity loading Hippety Hoppety at Origin 2 with Hippety Hoppety and transporting to Destination 2 unloading with Hippety Hoppety",
+            "time": 118253,
+            "value": -1
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              4
+            ]
+          },
+          "properties": {
+            "message": "transporting start",
+            "time": 118253,
+            "value": 3000
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "transporting stop",
+            "time": 236507,
+            "value": 3000
+          }
+        },
+        {
+          "type": "Feature",
+          "geometry": {
+            "type": "Point",
+            "coordinates": [
+              53,
+              3
+            ]
+          },
+          "properties": {
+            "message": "completed single_run activity loading Hippety Hoppety at Origin 2 with Hippety Hoppety and transporting to Destination 2 unloading with Hippety Hoppety",
+            "time": 236507,
+            "value": -1
+          }
+        }
+      ]
+    }
+  ],
+  "completionTime": 236507.45144985252
+}

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -102,6 +102,26 @@ def test_depth_restriction():
     )
 
 
+def test_sequential_activity():
+    """Runs a simulation with two ships, both ships have their own origin and destination, and each will
+    complete a single dredging run. These activities can be done in parallel, but because they are put into
+    a sequential activity, we expect them to take place sequentially, i.e., the second ship should not start
+    its dredge run until the first ship has completed its run."""
+    result = run_and_compare_completion_time(
+        config_file='tests/configs/sequential_activity.json',
+        expected_result_file='tests/results/sequential_activity_result.json'
+    )
+    hopper1 = result['equipment'][0]
+    assert hopper1['id'] == 'hopper1'
+
+    hopper2 = result['equipment'][1]
+    assert hopper2['id'] == 'hopper2'
+
+    hopper1_done_time = hopper1['features'][-1]['properties']['time']
+    hopper2_start_time = hopper2['features'][0]['properties']['time']
+    assert hopper1_done_time <= hopper2_start_time
+
+
 @pytest.mark.timeout(60)
 def test_infinite_loop_detection():
     """Run a simulation that would lead to an infinite loop."""


### PR DESCRIPTION
Add a new activity type 'sequential' to Simulation which executes the given (sub)activities in sequential order.

This can be used by the blockly environment to make sure activity blocks placed underneath each other, are executed in that order even if they apply to different equipment.