### PR TITLE
Fixed resources issue

### DIFF
--- a/openclsim/model.py
+++ b/openclsim/model.py
@@ -356,9 +356,12 @@ def single_run_process(
             _release_resource(
                 resource_requests, loader.resource, kept_resource=mover.resource
             )
-            _release_resource(
-                resource_requests, origin.resource, kept_resource=mover.resource
-            )
+            
+            # If the loader is not the origin, release the origin as well
+            if origin.resource in resource_requests.keys():
+                _release_resource(
+                    resource_requests, origin.resource, kept_resource=mover.resource
+                )
 
         for i in destinations.index:
             destination = destinations.loc[i, "ID"]


### PR DESCRIPTION
Fixed the error of issue #85, this should be working now. The problem was that all "used" resources were released without checking if these resources were actually still being held by the activity. In the case of issue #85 this was not the case, because the origin and the loader shared the same resource.

@Pietervanhalem please check if the change works as expected.

