### PR TITLE
fix bug

### DIFF
--- a/openclsim/core.py
+++ b/openclsim/core.py
@@ -1420,17 +1420,16 @@ class Routeable(Movable):
             if destination.name in list(self.env.FG.nodes):
                 return nx.dijkstra_path(self.env.FG, origin, destination.name)
 
-        else:
-            for node in geom.keys():
-                if (
-                    destination.geometry.x == geom[node].x
-                    and destination.geometry.y == geom[node].y
-                ):
-                    destination = node
-                    return nx.dijkstra_path(self.env.FG, origin, destination)
+        for node in geom.keys():
+            if (
+                destination.geometry.x == geom[node].x
+                and destination.geometry.y == geom[node].y
+            ):
+                destination = node
+                return nx.dijkstra_path(self.env.FG, origin, destination)
 
-            # If no route is returned
-            raise AssertionError("The destination cannot be found in the graph")
+        # If no route is returned
+        raise AssertionError("The destination cannot be found in the graph")
 
     def determine_speed(self, node_from, node_to):
         """ Determine the sailing speed based on edge properties """


### PR DESCRIPTION
When destination has the attribute name but the name is not in the graph the find route will return ```None``` without giving a warning. By removing the else statement the function will continue when the destination has the attribute name but the name is not in the graph. This fixes the bug