### PR TITLE
Add notebook terra et aqua

### DIFF
--- a/notebooks/34_fleet_optimization.m
+++ b/notebooks/34_fleet_optimization.m
@@ -1,0 +1,81 @@
+// BI: PowerBI load script for notebook 34_fleet_optimization
+// notebooks_folder: https://powerbi.tips/2016/08/using-variables-for-file-locations/
+
+//Schedule
+let
+    Source = Csv.Document(File.Contents(notebooks_folder &  "activity_logs.csv"),[Delimiter=",", Columns=7, Encoding=1252, QuoteStyle=QuoteStyle.None]),
+    #"Promoted Headers" = Table.PromoteHeaders(Source, [PromoteAllScalars=true]),
+    #"Split Column by Delimiter" = Table.SplitColumn(#"Promoted Headers", "ActivityName", Splitter.SplitTextByDelimiter(":", QuoteStyle.Csv), {"ActivityName.1", "ActivityName.2"}),
+    #"Changed Type" = Table.TransformColumnTypes(#"Split Column by Delimiter",{{"trip", Int64.Type}, {"ActivityID", type text}, {"ActivityName.1", type text}, {"ActivityName.2", type text}, {"ActivityClass", type text}, {"TimestampStart", type datetime}, {"TimestampStop", type datetime}, {"TimestampDt", Int64.Type}}),
+    #"Renamed Columns" = Table.RenameColumns(#"Changed Type",{{"ActivityName.1", "ActivityType"}, {"ActivityName.2", "ActivityName"}}),
+    #"Removed Columns" = Table.RemoveColumns(#"Renamed Columns",{"ActivityType", "ActivityName"}),
+    #"Added Custom" = Table.AddColumn(#"Removed Columns", "Custom", each [ActivityID]&":"& Number.ToText([trip])),
+    #"Renamed Columns1" = Table.RenameColumns(#"Added Custom",{{"Custom", "uuid"}}),
+    #"Reordered Columns" = Table.ReorderColumns(#"Renamed Columns1",{"uuid", "trip", "ActivityID", "ActivityClass", "TimestampStart", "TimestampStop", "TimestampDt"})
+in
+    #"Reordered Columns"
+	
+//Planning
+let
+    Source = Csv.Document(File.Contents(notebooks_folder &  "activities.csv"),[Delimiter=",", Columns=14, Encoding=1252, QuoteStyle=QuoteStyle.None]),
+    #"Promoted Headers" = Table.PromoteHeaders(Source, [PromoteAllScalars=true]),
+    #"Split Column by Delimiter" = Table.SplitColumn(#"Promoted Headers", "ActivityName", Splitter.SplitTextByDelimiter(":", QuoteStyle.Csv), {"ActivityName.1", "ActivityName.2"}),
+    #"Changed Type" = Table.TransformColumnTypes(#"Split Column by Delimiter",{{"ActivityID", type text}, {"ActivityName.1", type text}, {"ActivityName.2", type text}, {"ActivityClass", type text}, {"ParentId", type text}, {"ParentName", type text}, {"ParentLevel", Int64.Type}, {"OriginID", type text}, {"OriginName", type text}, {"DestinationID", type text}, {"DestinationName", type text}, {"ProcessorID", type text}, {"ProcessorName", type text}, {"MoverID", type text}, {"MoverName", type text}}),
+    #"Renamed Columns" = Table.RenameColumns(#"Changed Type",{{"ActivityName.1", "ActivityType"}, {"ActivityName.2", "ActivityName"}}),
+    #"Added Custom" = Table.AddColumn(#"Renamed Columns", "Custom", each [ProcessorName] & " " & [MoverName] & " " & [DestinationName]),
+    #"Renamed Columns1" = Table.RenameColumns(#"Added Custom",{{"Custom", "ResourceSetName"}}),
+    #"Filtered Rows" = Table.SelectRows(#"Renamed Columns1", each ([ActivityType] <> "sequential_activity_subcycle" and [ActivityType] <> "while_sequential_activity_subcycle"))
+in
+    #"Filtered Rows"
+	
+//Vessels
+let
+    Source = Csv.Document(File.Contents(notebooks_folder &  "concepts.csv"),[Delimiter=",", Columns=3, Encoding=1252, QuoteStyle=QuoteStyle.None]),
+    #"Changed Type" = Table.TransformColumnTypes(Source,{{"Column1", type text}, {"Column2", type text}, {"Column3", type text}}),
+    #"Promoted Headers" = Table.PromoteHeaders(#"Changed Type", [PromoteAllScalars=true]),
+    #"Changed Type1" = Table.TransformColumnTypes(#"Promoted Headers",{{"ConceptName", type text}, {"ConceptID", type text}, {"ConceptClass", type text}}),
+    #"Filtered Rows" = Table.SelectRows(#"Changed Type1", each ([ConceptClass] = "TransportProcessingResource")),
+    #"Renamed Columns" = Table.RenameColumns(#"Filtered Rows",{{"ConceptName", "VesselName"}, {"ConceptID", "ConceptID"}, {"ConceptClass", "VesselClass"}})
+in
+    #"Renamed Columns"
+
+//Sites
+let
+    Source = Csv.Document(File.Contents(notebooks_folder &  "concepts.csv"),[Delimiter=",", Columns=3, Encoding=1252, QuoteStyle=QuoteStyle.None]),
+    #"Changed Type" = Table.TransformColumnTypes(Source,{{"Column1", type text}, {"Column2", type text}, {"Column3", type text}}),
+    #"Promoted Headers" = Table.PromoteHeaders(#"Changed Type", [PromoteAllScalars=true]),
+    #"Changed Type1" = Table.TransformColumnTypes(#"Promoted Headers",{{"ConceptName", type text}, {"ConceptID", type text}, {"ConceptClass", type text}}),
+    #"Filtered Rows" = Table.SelectRows(#"Changed Type1", each ([ConceptClass] = "Site")),
+    #"Renamed Columns" = Table.RenameColumns(#"Filtered Rows",{{"ConceptClass", "SiteClass"}, {"ConceptName", "SiteName"}})
+in
+    #"Renamed Columns"
+
+//Campaigns
+let
+    Source = Csv.Document(File.Contents(notebooks_folder &  "resources.csv"),[Delimiter=",", Columns=6, Encoding=1252, QuoteStyle=QuoteStyle.None]),
+    #"Changed Type" = Table.TransformColumnTypes(Source,{{"Column1", type text}, {"Column2", type text}, {"Column3", type text}, {"Column4", type text}, {"Column5", type text}, {"Column6", type text}}),
+    #"Promoted Headers" = Table.PromoteHeaders(#"Changed Type", [PromoteAllScalars=true]),
+    #"Changed Type1" = Table.TransformColumnTypes(#"Promoted Headers",{{"ActivityID", type text}, {"ActivityName", type text}, {"ActivityClass", type text}, {"ConceptID", type text}, {"ConceptName", type text}, {"ConceptMode", type text}}),
+    #"Merged Queries" = Table.NestedJoin(#"Changed Type1", {"ConceptID"}, Vessels, {"ConceptID"}, "Vessels", JoinKind.LeftOuter),
+    #"Expanded Vessels" = Table.ExpandTableColumn(#"Merged Queries", "Vessels", {"VesselName", "VesselClass"}, {"Vessels.VesselName", "Vessels.VesselClass"})
+in
+    #"Expanded Vessels"
+
+//Activities (alas, we cannot code colors in load script)
+let
+    Query1 = #table(
+ type table
+    [
+        #"Number Column"=number, 
+        #"Text Column"=text
+    ], 
+ {
+  {1,"sailing full"},
+  {2,"sailing empty"},
+  {3,"loading"},
+  {4,"unloading"}  
+ }
+),
+    #"Renamed Columns" = Table.RenameColumns(Query1,{{"Text Column", "ActivityType"}})
+in
+    #"Renamed Columns"	

--- a/notebooks/34_fleet_optimization.qvs
+++ b/notebooks/34_fleet_optimization.qvs
@@ -1,0 +1,71 @@
+// BI: Qlik Sense load script for notebook 34_fleet_optimization
+
+Schedule:
+LOAD
+    trip,
+    ActivityID,
+    ActivityID & ':' & trip as uuid,
+    TimeStamp(TimestampStart) as TimestampStart,
+    TimeStamp(TimestampStop) as TimestampStop,
+    TimestampDt
+FROM [lib://notebooks_folder/activity_logs.csv]
+(txt, codepage is 28592, embedded labels, delimiter is ',', msq);
+
+Planning:
+LOAD
+    ActivityID,
+    subfield(ActivityName,':',1) as ActivityType,
+    subfield(ActivityName,':',2) as ActivityName,
+    ActivityClass,
+    ParentId,
+    ParentName,
+    ParentLevel,
+    OriginID,
+    OriginName,
+    DestinationID,
+    DestinationName,
+    ProcessorID,
+    ProcessorName,
+    MoverID,
+    MoverName,
+    MoverName & '' & ProcessorName as ResourceSetName
+FROM [lib://notebooks_folder/activities.csv]
+(txt, codepage is 28592, embedded labels, delimiter is ',', msq)
+where (subfield(ActivityName,':',1)<>'sequential_activity_subcycle') and
+      (subfield(ActivityName,':',1)<>'while_sequential_activity_subcycle');
+
+Vessels:
+LOAD
+    ConceptName as VesselName,
+    ConceptID ,
+    ConceptClass as VesselClass
+FROM [lib://notebooks_folder/concepts.csv]
+(txt, codepage is 28591, embedded labels, delimiter is ',', msq)
+where ConceptClass='TransportProcessingResource';
+
+Sites:
+LOAD
+    ConceptName as SiteName,
+    ConceptID ,
+    ConceptClass as SiteClass
+FROM [lib://notebooks_folder/concepts.csv]
+(txt, codepage is 28591, embedded labels, delimiter is ',', msq)
+where ConceptClass='Site';
+
+Campaigns:
+LOAD
+    ActivityID,
+    ConceptID,
+    ConceptMode as ResourceMode
+FROM [lib://notebooks_folder/resources.csv]
+(txt, codepage is 28591, embedded labels, delimiter is ',', msq);
+
+Activities:
+load * inline [
+ActivityType.colorid,ActivityType.color,ActivityType
+1,#253a79,sailing full
+3,#cccee3,sailing empty
+5,#ffb702,loading
+6,#ff8702,unloading
+];
+

--- a/src/openclsim/io.py
+++ b/src/openclsim/io.py
@@ -2,6 +2,7 @@ import pandas as pd
 
 from openclsim.plot import get_log_dataframe
 
+
 def get_tree_as_list(treelist, depth=0) -> dict:
     """recursively flatten a tree of activities into dict of lists.
 
@@ -13,7 +14,7 @@ def get_tree_as_list(treelist, depth=0) -> dict:
 
     Example:
         get_tree_as_list(activities)['activity']
-    
+
     Parameters
     ----------
     treelist
@@ -25,55 +26,63 @@ def get_tree_as_list(treelist, depth=0) -> dict:
     --------
     activity_dict : dict
         a dict with fields
-           ActivityID, ActivityClass,ActivityName,
+           ActivityID,   ActivityClass,ActivityName,
            ParentId,ParentName,ParentLevel,
            activity
 
     """
 
-    if isinstance(treelist,list):
+    if isinstance(treelist, list):
         pass
-    elif isinstance(treelist,dict):
+    elif isinstance(treelist, dict):
         treelist = [*treelist.values()]
     else:
         treelist = [treelist]
-        
+
     activity = [x for x in treelist]
     ActivityID = [x.id for x in treelist]
     ActivityName = [x.name for x in treelist]
     ActivityClass = [type(x).__name__ for x in treelist]
-    ParentId = [None,]*len(ActivityID)
-    ParentName = ['',]*len(ActivityID)
-    ParentLevel = [depth,]*len(ActivityID)
-    
+    ParentId = [
+        None,
+    ] * len(ActivityID)
+    ParentName = [
+        "",
+    ] * len(ActivityID)
+    ParentLevel = [
+        depth,
+    ] * len(ActivityID)
+
     for i, act in enumerate(treelist):
         if hasattr(act, "sub_processes"):
-            d = get_tree_as_list(act.sub_processes, depth+1)
-            ActivityID += d['ActivityID']
-            activity+=d['activity']
-            ParentId +=[act.id]*len(d['activity'])
-            ParentName +=[act.name]*len(d['ParentName'])
-            ActivityClass +=d['ActivityClass']
-            ActivityName +=d['ActivityName']
-            ParentLevel +=d['ParentLevel']
-           
-    return {'ActivityID':ActivityID,
-            'ActivityName':ActivityName,
-            'ActivityClass':ActivityClass,
-            'ParentId':ParentId,
-            'ParentName':ParentName,
-            'ParentLevel':ParentLevel,
-            'activity':activity}
+            d = get_tree_as_list(act.sub_processes, depth + 1)
+            ActivityID += d["ActivityID"]
+            activity += d["activity"]
+            ParentId += [act.id] * len(d["activity"])
+            ParentName += [act.name] * len(d["ParentName"])
+            ActivityClass += d["ActivityClass"]
+            ActivityName += d["ActivityName"]
+            ParentLevel += d["ParentLevel"]
+
+    return {
+        "ActivityID": ActivityID,
+        "ActivityName": ActivityName,
+        "ActivityClass": ActivityClass,
+        "ParentId": ParentId,
+        "ParentName": ParentName,
+        "ParentLevel": ParentLevel,
+        "activity": activity,
+    }
 
 
 def get_activity_resources(activities, ofile=None):
     """Extract the resources assigned to an activity to a resolved list
 
-    Note these are just the model-defined activities and the 
-    mover, processor, origin and destination relations 
+    Note these are just the model-defined activities and the
+    mover, processor, origin and destination relations
     without the log. activities thasty have no concept assigned
     to it, are not exported. Use export_activities() for that.
-    
+
     Note that 1 acticvity can have multiple concepts assigned
     to it simultaneously.
 
@@ -86,7 +95,7 @@ def get_activity_resources(activities, ofile=None):
     activities
         hierarchical activities to be resolved and stored
     concept_name
-        optional filter the flattened list for one 
+        optional filter the flattened list for one
         concept_name (Sites and Vessels). Default: None
     ofile
         name of a csv file to which to export the list (optional)
@@ -95,33 +104,43 @@ def get_activity_resources(activities, ofile=None):
     df = pd.DataFrame(get_tree_as_list(activities))
 
     li = []
-    for attr_name in ['processor','mover', 'origin', 'destination']:
-        mask   = [hasattr(x,attr_name) for x in df['activity']]
-        li+=[(x.id,
-              x.name,
-              type(x).__name__,
-              getattr(getattr(x,attr_name),'id'),
-              getattr(getattr(x,attr_name),'name'),
-              attr_name) for x in df[mask]['activity']]
+    for attr_name in ["processor", "mover", "origin", "destination"]:
+        mask = [hasattr(x, attr_name) for x in df["activity"]]
+        li += [
+            (
+                x.id,
+                x.name,
+                type(x).__name__,
+                getattr(getattr(x, attr_name), "id"),
+                getattr(getattr(x, attr_name), "name"),
+                attr_name,
+            )
+            for x in df[mask]["activity"]
+        ]
     tmp = list(zip(*li))
-    res = pd.DataFrame.from_dict({'ActivityID':tmp[0],
-                                  'ActivityName':tmp[1],
-                                  'ActivityClass':tmp[2],
-                                  'ConceptID':tmp[3],
-                                  'ConceptName':tmp[4],
-                                  'ConceptMode':tmp[5]})
-    
+    res = pd.DataFrame.from_dict(
+        {
+            "ActivityID": tmp[0],
+            "ActivityName": tmp[1],
+            "ActivityClass": tmp[2],
+            "ConceptID": tmp[3],
+            "ConceptName": tmp[4],
+            "ConceptMode": tmp[5],
+        }
+    )
+
     if ofile:
         res.to_csv(ofile, index=False)
 
     return res
+
 
 def get_ranges_dataframe(simulation_object, id_map=None):
     """Get the chronological ranges of one simulation object in a pandas dataframe.
 
     Turns a log of length (2*n) of START, STOP events at t=Timestamp into
     a log of length (n) of ranges between t=[TimestampStart, TimestampStop]
-    
+
     The result is sorted by Timestamp
 
     Parameters
@@ -133,59 +152,73 @@ def get_ranges_dataframe(simulation_object, id_map=None):
         * a list or dict of concepts
         * a manual id_map to resolve concept uuids to labels, e.g. {'uuid1':'vessel A'}
     """
-    
+
     log = get_log_dataframe(simulation_object, id_map=id_map)
-    
-    idkey='Activity' # ActivityID
-    
+
+    idkey = "Activity"  # ActivityID
+
     li = []
-    
+
     # do this analysis per ActivityID
     # each intervals has START STOP
     # at most 1 interval may be without STOP, the last one
-    
+
     for ActivityID in set(log[idkey]):
+        log1 = log[log[idkey] == ActivityID]
 
-        log1 = log[log[idkey]==ActivityID]
+        t0 = log1[log1["ActivityState"] == "START"].rename(
+            columns={"Timestamp": "TimestampStart"}
+        )
+        t1 = log1[log1["ActivityState"] == "STOP"].rename(
+            columns={"Timestamp": "TimestampStop"}
+        )
 
-        t0 = log1[log1['ActivityState']=='START'].rename(columns={'Timestamp':'TimestampStart'})
-        t1 = log1[log1['ActivityState']=='STOP'].rename(columns={'Timestamp':'TimestampStop'})
-        
         # add geometry?
-        if 'container level' in log1.keys():
-            t0 = t0[['TimestampStart','container level']].rename(columns={'container level':'ContainerLevelStart'})
-            t1 = t1[['TimestampStop','container level']].rename(columns={'container level':'ContainerLevelStop'})
+        if "container level" in log1.keys():
+            t0 = t0[["TimestampStart", "container level"]].rename(
+                columns={"container level": "ContainerLevelStart"}
+            )
+            t1 = t1[["TimestampStop", "container level"]].rename(
+                columns={"container level": "ContainerLevelStop"}
+            )
         else:
-            t0 = t0[['TimestampStart']]
-            t1 = t1[['TimestampStop']]
-        
-        t0['trip'] = range(1,len(t0)+1)
-        t1['trip'] = range(1,len(t1)+1)
-        
-        if len(t0)==len(t1):
+            t0 = t0[["TimestampStart"]]
+            t1 = t1[["TimestampStop"]]
+
+        t0["trip"] = range(1, len(t0) + 1)
+        t1["trip"] = range(1, len(t1) + 1)
+
+        if len(t0) == len(t1):
             pass
-        elif len(t0)==len(t1)+1:
-            print('END missing')
-            dt1 = pd.DataFrame.from_dict({'trip':[len(t0)],'TimestampStop':[None]}) # will give NaT
+        elif len(t0) == len(t1) + 1:
+            print("END missing")
+            dt1 = pd.DataFrame.from_dict(
+                {"trip": [len(t0)], "TimestampStop": [None]}
+            )  # will give NaT
             t1 = pd.concat([t1, dt1], ignore_index=True)
         else:
-            raise Exception('At most 1 range may be without STOP')
-        s = t0.merge(t1, on='trip')
-        
+            raise Exception("At most 1 range may be without STOP")
+        s = t0.merge(t1, on="trip")
+
         s[idkey] = ActivityID
-        dt = s['TimestampStop'] - s['TimestampStart']
+        dt = s["TimestampStop"] - s["TimestampStart"]
         # powerbi gannt can only handle integer durations. so use a small unit:sec
-        s['TimestampDt'] = [x.total_seconds() for x in dt]
+        s["TimestampDt"] = [x.total_seconds() for x in dt]
         li.append(s)
-        
+
     R = pd.concat(li)
     R = R.sort_values(by=["TimestampStart"])
-        
+
     return R
 
-def get_concepts(concepts, namespace='', ofile=None,):
+
+def get_concepts(
+    concepts,
+    namespace="",
+    ofile=None,
+):
     """Save the concepts vities to a resolved csv file
-    
+
     Concepts can be stored in 1 file (Sites and Vessels)
     or they can  be stored mixed together.
 
@@ -203,25 +236,28 @@ def get_concepts(concepts, namespace='', ofile=None,):
         * a list or dict of concepts
         * a manual id_map to resolve concept uuids to labels, e.g. {'uuid1':'vessel A'}
     """
-    
-    if isinstance(concepts,dict):
-        concepts = [*concepts.values()] 
-    
-    df= {f'{namespace}Name':[x.name for x in concepts],
-         f'{namespace}ID':[x.id for x in concepts],
-         f'{namespace}Class':[type(x).__name__ for x in concepts]}
-    
+
+    if isinstance(concepts, dict):
+        concepts = [*concepts.values()]
+
+    df = {
+        f"{namespace}Name": [x.name for x in concepts],
+        f"{namespace}ID": [x.id for x in concepts],
+        f"{namespace}Class": [type(x).__name__ for x in concepts],
+    }
+
     df = pd.DataFrame(df)
     if ofile:
         df.to_csv(ofile, index=False)
-    
+
     return df
+
 
 def get_activities(activities, ofile=None):
     """Save the activities tree to a resolved list in a csv file
 
-    Note these are just the model-defined activities and the 
-    mover, processor, origin and destination relations 
+    Note these are just the model-defined activities and the
+    mover, processor, origin and destination relations
     without the log.
 
     returned keys are
@@ -239,46 +275,60 @@ def get_activities(activities, ofile=None):
     ofile
         name of csv file to be exported
     """
-    
+
     df = pd.DataFrame(get_tree_as_list(activities))
-    
-    processor   = [x.processor   if hasattr(x,'processor')   else None for x in df['activity']]
-    mover       = [x.mover       if hasattr(x,'mover')       else None for x in df['activity']]
-    origin      = [x.origin      if hasattr(x,'origin')      else None for x in df['activity']]
-    destination = [x.destination if hasattr(x,'destination') else None for x in df['activity']]
-    
-    df['ProcessorID']   = [x.id if x else None for x in processor]
-    df['MoverID']       = [x.id if x else None for x in mover]
-    df['OriginID']      = [x.id if x else None for x in origin]
-    df['DestinationID'] = [x.id if x else None for x in destination]
-    
-    df['ProcessorName']   = [x.name if x else '' for x in processor]
-    df['MoverName']       = [x.name if x else '' for x in mover]
-    df['OriginName']      = [x.name if x else '' for x in origin]
-    df['DestinationName'] = [x.name if x else '' for x in destination]
+
+    processor = [
+        x.processor if hasattr(x, "processor") else None for x in df["activity"]
+    ]
+    mover = [x.mover if hasattr(x, "mover") else None for x in df["activity"]]
+    origin = [x.origin if hasattr(x, "origin") else None for x in df["activity"]]
+    destination = [
+        x.destination if hasattr(x, "destination") else None for x in df["activity"]
+    ]
+
+    df["ProcessorID"] = [x.id if x else None for x in processor]
+    df["MoverID"] = [x.id if x else None for x in mover]
+    df["OriginID"] = [x.id if x else None for x in origin]
+    df["DestinationID"] = [x.id if x else None for x in destination]
+
+    df["ProcessorName"] = [x.name if x else "" for x in processor]
+    df["MoverName"] = [x.name if x else "" for x in mover]
+    df["OriginName"] = [x.name if x else "" for x in origin]
+    df["DestinationName"] = [x.name if x else "" for x in destination]
 
     # manually set column order + exclude actual 'activity' object !
-    
-    keys  = ['ActivityID','ActivityName','ActivityClass',
-             'ParentId','ParentName','ParentLevel',
-             'OriginID','OriginName',
-             'DestinationID','DestinationName',
-             'ProcessorID','ProcessorName',
-             'MoverID', 'MoverName'
-            ]
-    
+
+    keys = [
+        "ActivityID",
+        "ActivityName",
+        "ActivityClass",
+        "ParentId",
+        "ParentName",
+        "ParentLevel",
+        "OriginID",
+        "OriginName",
+        "DestinationID",
+        "DestinationName",
+        "ProcessorID",
+        "ProcessorName",
+        "MoverID",
+        "MoverName",
+    ]
+
     df = pd.DataFrame(df)
-        
+
     if ofile:
-        df.to_csv(ofile, columns = keys, index=False)
-    
+        df.to_csv(ofile, columns=keys, index=False)
+
     return df
 
-def get_activity_log(activities, ofile = None):
+
+def get_activity_log(activities, ofile=None):
     """Save log of activities to a resolved start-stop list in a csv file
 
-    This export of the logged time ranges can be used to plot Gannt 
-    charts in for instance Qlik and PowerBI. Load the coupled export_activities() 
+    This export of the logged time ranges can be used to plot Gannt
+    charts in for instance Qlik and PowerBI. Load the coupled export_activities()
     file to resolve the Activty properties and relations to (Sites and Vessels).
 
 
@@ -291,22 +341,29 @@ def get_activity_log(activities, ofile = None):
     """
 
     df = pd.DataFrame(get_tree_as_list(activities))
-    
+
     li = []
     for i, rowi in df.iterrows():
-        log = get_ranges_dataframe(rowi['activity'])
-        log.rename(columns={'Activity':'ActivityID'}, inplace=True)
+        log = get_ranges_dataframe(rowi["activity"])
+        log.rename(columns={"Activity": "ActivityID"}, inplace=True)
         li.append(log)
     ActivityRanges = pd.concat(li)
-    
-    ActivityRanges = ActivityRanges.merge(df[['ActivityID', 'ActivityName', 'ActivityClass']], on='ActivityID', how='left')
-    
-    keys  = ['trip',
-             'ActivityID','ActivityName','ActivityClass',
-             'TimestampStart','TimestampStop','TimestampDt']
-        
-    if ofile:
-        ActivityRanges.to_csv(ofile, columns = keys, index=False)
-    
-    return ActivityRanges.sort_values(by=["TimestampStart"])
 
+    ActivityRanges = ActivityRanges.merge(
+        df[["ActivityID", "ActivityName", "ActivityClass"]], on="ActivityID", how="left"
+    )
+
+    keys = [
+        "trip",
+        "ActivityID",
+        "ActivityName",
+        "ActivityClass",
+        "TimestampStart",
+        "TimestampStop",
+        "TimestampDt",
+    ]
+
+    if ofile:
+        ActivityRanges.to_csv(ofile, columns=keys, index=False)
+
+    return ActivityRanges.sort_values(by=["TimestampStart"])

--- a/src/openclsim/io.py
+++ b/src/openclsim/io.py
@@ -32,7 +32,7 @@ def get_tree_as_list(treelist, depth=0) -> dict:
     """
 
     if isinstance(treelist,list):
-        treelist = treelist
+        pass
     elif isinstance(treelist,dict):
         treelist = [*treelist.values()]
     else:

--- a/src/openclsim/io.py
+++ b/src/openclsim/io.py
@@ -1,0 +1,312 @@
+import pandas as pd
+
+from openclsim.plot import get_log_dataframe
+
+def get_tree_as_list(treelist, depth=0) -> dict:
+    """recursively flatten a tree of activities into dict of lists.
+
+    Returns a dict with fields:
+    ActivityID, ActivityName, activity,
+    ParentId, ParentName, ParentLevel
+
+    The tree can be reconstructed from the Parent relations.
+
+    Example:
+        get_tree_as_list(activities)['activity']
+    
+    Parameters
+    ----------
+    treelist
+        one activity, or list or dict with activities
+    depth
+        depth level of top of hierarchy (default 0)
+
+    Returns
+    --------
+    activity_dict : dict
+        a dict with fields
+           ActivityID, ActivityClass,ActivityName,
+           ParentId,ParentName,ParentLevel,
+           activity
+
+    """
+
+    if isinstance(treelist,list):
+        treelist = treelist
+    elif isinstance(treelist,dict):
+        treelist = [*treelist.values()]
+    else:
+        treelist = [treelist]
+        
+    activity = [x for x in treelist]
+    ActivityID = [x.id for x in treelist]
+    ActivityName = [x.name for x in treelist]
+    ActivityClass = [type(x).__name__ for x in treelist]
+    ParentId = [None,]*len(ActivityID)
+    ParentName = ['',]*len(ActivityID)
+    ParentLevel = [depth,]*len(ActivityID)
+    
+    for i, act in enumerate(treelist):
+        if hasattr(act, "sub_processes"):
+            d = get_tree_as_list(act.sub_processes, depth+1)
+            ActivityID += d['ActivityID']
+            activity+=d['activity']
+            ParentId +=[act.id]*len(d['activity'])
+            ParentName +=[act.name]*len(d['ParentName'])
+            ActivityClass +=d['ActivityClass']
+            ActivityName +=d['ActivityName']
+            ParentLevel +=d['ParentLevel']
+           
+    return {'ActivityID':ActivityID,
+            'ActivityName':ActivityName,
+            'ActivityClass':ActivityClass,
+            'ParentId':ParentId,
+            'ParentName':ParentName,
+            'ParentLevel':ParentLevel,
+            'activity':activity}
+
+
+def get_activity_resources(activities, ofile=None):
+    """Extract the resources assigned to an activity to a resolved list
+
+    Note these are just the model-defined activities and the 
+    mover, processor, origin and destination relations 
+    without the log. activities thasty have no concept assigned
+    to it, are not exported. Use export_activities() for that.
+    
+    Note that 1 acticvity can have multiple concepts assigned
+    to it simultaneously.
+
+    returned keys are
+            'ActivityID','ActivityName','ActivityClass',
+            'ConceptID','ConceptName','ConceptMode'
+
+    Parameters
+    ----------
+    activities
+        hierarchical activities to be resolved and stored
+    concept_name
+        optional filter the flattened list for one 
+        concept_name (Sites and Vessels). Default: None
+    ofile
+        name of a csv file to which to export the list (optional)
+    """
+
+    df = pd.DataFrame(get_tree_as_list(activities))
+
+    li = []
+    for attr_name in ['processor','mover', 'origin', 'destination']:
+        mask   = [hasattr(x,attr_name) for x in df['activity']]
+        li+=[(x.id,
+              x.name,
+              type(x).__name__,
+              getattr(getattr(x,attr_name),'id'),
+              getattr(getattr(x,attr_name),'name'),
+              attr_name) for x in df[mask]['activity']]
+    tmp = list(zip(*li))
+    res = pd.DataFrame.from_dict({'ActivityID':tmp[0],
+                                  'ActivityName':tmp[1],
+                                  'ActivityClass':tmp[2],
+                                  'ConceptID':tmp[3],
+                                  'ConceptName':tmp[4],
+                                  'ConceptMode':tmp[5]})
+    
+    if ofile:
+        res.to_csv(ofile, index=False)
+
+    return res
+
+def get_ranges_dataframe(simulation_object, id_map=None):
+    """Get the chronological ranges of one simulation object in a pandas dataframe.
+
+    Turns a log of length (2*n) of START, STOP events at t=Timestamp into
+    a log of length (n) of ranges between t=[TimestampStart, TimestampStop]
+    
+    The result is sorted by Timestamp
+
+    Parameters
+    ----------
+    simulation_object
+        object from which the log is returned as a dataframe sorted by "Timestamp"
+    id_map
+        by default uuids are not resolved. id_map solves this at request:
+        * a list or dict of concepts
+        * a manual id_map to resolve concept uuids to labels, e.g. {'uuid1':'vessel A'}
+    """
+    
+    log = get_log_dataframe(simulation_object, id_map=id_map)
+    
+    idkey='Activity' # ActivityID
+    
+    li = []
+    
+    # do this analysis per ActivityID
+    # each intervals has START STOP
+    # at most 1 interval may be without STOP, the last one
+    
+    for ActivityID in set(log[idkey]):
+
+        log1 = log[log[idkey]==ActivityID]
+
+        t0 = log1[log1['ActivityState']=='START'].rename(columns={'Timestamp':'TimestampStart'})
+        t1 = log1[log1['ActivityState']=='STOP'].rename(columns={'Timestamp':'TimestampStop'})
+        
+        # add geometry?
+        if 'container level' in log1.keys():
+            t0 = t0[['TimestampStart','container level']].rename(columns={'container level':'ContainerLevelStart'})
+            t1 = t1[['TimestampStop','container level']].rename(columns={'container level':'ContainerLevelStop'})
+        else:
+            t0 = t0[['TimestampStart']]
+            t1 = t1[['TimestampStop']]
+        
+        t0['trip'] = range(1,len(t0)+1)
+        t1['trip'] = range(1,len(t1)+1)
+        
+        if len(t0)==len(t1):
+            pass
+        elif len(t0)==len(t1)+1:
+            print('END missing')
+            dt1 = pd.DataFrame.from_dict({'trip':[len(t0)],'TimestampStop':[None]}) # will give NaT
+            t1 = pd.concat([t1, dt1], ignore_index=True)
+        else:
+            raise Exception('At most 1 range may be without STOP')
+        s = t0.merge(t1, on='trip')
+        
+        s[idkey] = ActivityID
+        dt = s['TimestampStop'] - s['TimestampStart']
+        # powerbi gannt can only handle integer durations. so use a small unit:sec
+        s['TimestampDt'] = [x.total_seconds() for x in dt]
+        li.append(s)
+        
+    R = pd.concat(li)
+    R = R.sort_values(by=["TimestampStart"])
+        
+    return R
+
+def get_concepts(concepts, namespace='', ofile=None,):
+    """Save the concepts vities to a resolved csv file
+    
+    Concepts can be stored in 1 file (Sites and Vessels)
+    or they can  be stored mixed together.
+
+    Parameters
+    ----------
+    concepts
+        concepts to be resolved and stored
+    namespace
+        str that will prepad the column names 'Name', 'ID', "Class".
+        e.g. Vessel, Site or Concept
+    ofile
+        name of csv file to be exported
+    id_map
+        by default uuids are not resolved. id_map solves this at request:
+        * a list or dict of concepts
+        * a manual id_map to resolve concept uuids to labels, e.g. {'uuid1':'vessel A'}
+    """
+    
+    if isinstance(concepts,dict):
+        concepts = [*concepts.values()] 
+    
+    df= {f'{namespace}Name':[x.name for x in concepts],
+         f'{namespace}ID':[x.id for x in concepts],
+         f'{namespace}Class':[type(x).__name__ for x in concepts]}
+    
+    df = pd.DataFrame(df)
+    if ofile:
+        df.to_csv(ofile, index=False)
+    
+    return df
+
+def get_activities(activities, ofile=None):
+    """Save the activities tree to a resolved list in a csv file
+
+    Note these are just the model-defined activities and the 
+    mover, processor, origin and destination relations 
+    without the log.
+
+    returned keys are
+            'ActivityID','ActivityName','ActivityClass',
+            'ParentId','ParentName','ParentLevel',
+            'OriginID','OriginName',
+            'DestinationID','DestinationName',
+            'ProcessorID','ProcessorName',
+            'MoverID', 'MoverName'
+
+    Parameters
+    ----------
+    activities
+        hierarchical activities to be resolved and stored
+    ofile
+        name of csv file to be exported
+    """
+    
+    df = pd.DataFrame(get_tree_as_list(activities))
+    
+    processor   = [x.processor   if hasattr(x,'processor')   else None for x in df['activity']]
+    mover       = [x.mover       if hasattr(x,'mover')       else None for x in df['activity']]
+    origin      = [x.origin      if hasattr(x,'origin')      else None for x in df['activity']]
+    destination = [x.destination if hasattr(x,'destination') else None for x in df['activity']]
+    
+    df['ProcessorID']   = [x.id if x else None for x in processor]
+    df['MoverID']       = [x.id if x else None for x in mover]
+    df['OriginID']      = [x.id if x else None for x in origin]
+    df['DestinationID'] = [x.id if x else None for x in destination]
+    
+    df['ProcessorName']   = [x.name if x else '' for x in processor]
+    df['MoverName']       = [x.name if x else '' for x in mover]
+    df['OriginName']      = [x.name if x else '' for x in origin]
+    df['DestinationName'] = [x.name if x else '' for x in destination]
+
+    # manually set column order + exclude actual 'activity' object !
+    
+    keys  = ['ActivityID','ActivityName','ActivityClass',
+             'ParentId','ParentName','ParentLevel',
+             'OriginID','OriginName',
+             'DestinationID','DestinationName',
+             'ProcessorID','ProcessorName',
+             'MoverID', 'MoverName'
+            ]
+    
+    df = pd.DataFrame(df)
+        
+    if ofile:
+        df.to_csv(ofile, columns = keys, index=False)
+    
+    return df
+
+def get_activity_log(activities, ofile = None):
+    """Save log of activities to a resolved start-stop list in a csv file
+
+    This export of the logged time ranges can be used to plot Gannt 
+    charts in for instance Qlik and PowerBI. Load the coupled export_activities() 
+    file to resolve the Activty properties and relations to (Sites and Vessels).
+
+
+    Parameters
+    ----------
+    activities
+        hierarchical activities to be resolved and stored
+    ofile
+        name of csv file to be exported
+    """
+
+    df = pd.DataFrame(get_tree_as_list(activities))
+    
+    li = []
+    for i, rowi in df.iterrows():
+        log = get_ranges_dataframe(rowi['activity'])
+        log.rename(columns={'Activity':'ActivityID'}, inplace=True)
+        li.append(log)
+    ActivityRanges = pd.concat(li)
+    
+    ActivityRanges = ActivityRanges.merge(df[['ActivityID', 'ActivityName', 'ActivityClass']], on='ActivityID', how='left')
+    
+    keys  = ['trip',
+             'ActivityID','ActivityName','ActivityClass',
+             'TimestampStart','TimestampStop','TimestampDt']
+        
+    if ofile:
+        ActivityRanges.to_csv(ofile, columns = keys, index=False)
+    
+    return ActivityRanges.sort_values(by=["TimestampStart"])
+

--- a/src/openclsim/plot/log_dataframe.py
+++ b/src/openclsim/plot/log_dataframe.py
@@ -6,7 +6,9 @@ from openclsim.model import get_subprocesses
 
 
 def get_log_dataframe(simulation_object, id_map=None):
-    """Get the log of the simulation objects in a pandas dataframe.
+    """Get the chronological log of one simulation object in a pandas dataframe.
+
+    result is sorted by Timestamp
 
     Parameters
     ----------
@@ -14,14 +16,17 @@ def get_log_dataframe(simulation_object, id_map=None):
         object from which the log is returned as a dataframe sorted by "Timestamp"
     id_map
         by default uuids are not resolved. id_map solves this at request:
-        * a list of top-activities of which also all sub-activities
+        * a list or dict of top-activities of which also all sub-activities
           will be resolved, e.g.: [while_activity]
         * a manual id_map to resolve uuids to labels, e.g. {'uuid1':'name1'}
     """
     if id_map is None:
         id_map = []
 
+    if isinstance(id_map, dict):
+        id_map = [*id_map.values()]    
     if isinstance(id_map, list):
+        # TO DO should in fact be recursive for nested activities
         id_map = {act.id: act.name for act in get_subprocesses(id_map)}
     else:
         id_map = id_map if id_map else {}

--- a/src/openclsim/plot/log_dataframe.py
+++ b/src/openclsim/plot/log_dataframe.py
@@ -24,7 +24,7 @@ def get_log_dataframe(simulation_object, id_map=None):
         id_map = []
 
     if isinstance(id_map, dict):
-        id_map = [*id_map.values()]    
+        id_map = [*id_map.values()]
     if isinstance(id_map, list):
         # TO DO should in fact be recursive for nested activities
         id_map = {act.id: act.name for act in get_subprocesses(id_map)}

--- a/src/openclsim/plot/vessel_planning.py
+++ b/src/openclsim/plot/vessel_planning.py
@@ -56,16 +56,16 @@ def get_gantt_chart(
     Parameters
     ----------
     concepts
-        a list or dict of vessels, sites or activities for which to plot all 
+        a list or dict of vessels, sites or activities for which to plot all
         activities, e.g.: [while_activity1, while_activity2] or
-        {'w1':while_activity1, 'w2:while_activity2'}. Combinations of list 
-        and dicts need to be merged first into 1 overall list or dict, e.g. 
+        {'w1':while_activity1, 'w2:while_activity2'}. Combinations of list
+        and dicts need to be merged first into 1 overall list or dict, e.g.
         concepts = [from_site, to_site, *vessels.values()]
     activities
         a list or dict of additional activities to be plotted, if not yet in concepts
     id_map
         by default only the legend labels of activities in concepts are resolved.
-        Activities associated with vessels and sites are not resolved. id_map 
+        Activities associated with vessels and sites are not resolved. id_map
         resolves the legend labels using extra metadata:
         * a list or dict of vessels
         * a manual id_map to resolve uuids to labels, e.g. {'uuid1':'name1'}
@@ -73,7 +73,7 @@ def get_gantt_chart(
     """
     default_blockwidth = 10
 
-     # unpack dict to list
+    # unpack dict to list
     if type(concepts) == dict:
         concepts = [*concepts.values()]
 

--- a/src/openclsim/plot/vessel_planning.py
+++ b/src/openclsim/plot/vessel_planning.py
@@ -56,17 +56,32 @@ def get_gantt_chart(
     Parameters
     ----------
     concepts
-        a list of vessels, sites or activities for which to plot all activities
+        a list or dict of vessels, sites or activities for which to plot all 
+        activities, e.g.: [while_activity1, while_activity2] or
+        {'w1':while_activity1, 'w2:while_activity2'}. Combinations of list 
+        and dicts need to be merged first into 1 overall list or dict, e.g. 
+        concepts = [from_site, to_site, *vessels.values()]
     activities
-        additional activities to be plotted, if not yet in concepts
+        a list or dict of additional activities to be plotted, if not yet in concepts
     id_map
-        by default only activity in concepts are resolved. Activities
-        associated with vessels and sites are not resolved. id_map solves this:
-        * a list of top-activities of which also all sub-activities
-          will be resolved, e.g.: [while_activity]
+        by default only the legend labels of activities in concepts are resolved.
+        Activities associated with vessels and sites are not resolved. id_map 
+        resolves the legend labels using extra metadata:
+        * a list or dict of vessels
         * a manual id_map to resolve uuids to labels, e.g. {'uuid1':'name1'}
+
     """
     default_blockwidth = 10
+
+     # unpack dict to list
+    if type(concepts) == dict:
+        concepts = [*concepts.values()]
+
+    if type(activities) == dict:
+        activities = [*activities.values()]
+
+    if type(id_map) == dict:
+        id_map = [*id_map.values()]
 
     if type(id_map) == list:
         id_map = {act.id: act.name for act in get_subprocesses(id_map)}

--- a/src/openclsim/plot/vessel_planning.py
+++ b/src/openclsim/plot/vessel_planning.py
@@ -33,11 +33,11 @@ def get_segments(df, activity, y_val):
     x = []
     y = []
     start = 0
-    for i in range(len(df)):
-        if "START" in df["activity_state"][i] and df["log_string"][i] == activity:
-            start = df.index[i]
-        elif "STOP" in df["activity_state"][i] and df["log_string"][i] == activity:
-            x.extend((start, start, df.index[i], df.index[i], df.index[i]))
+    for index, row in df.iterrows():
+        if "START" in row["activity_state"] and row["log_string"] == activity:
+            start = index
+        elif "STOP" in row["activity_state"] and row["log_string"] == activity:
+            x.extend((start, start, index, index, index))
             y.extend((y_val, y_val, y_val, y_val, None))
     return x, y
 


### PR DESCRIPTION
For the upcoming lecture, I made the case in the Terra et Aqua paper work in python 3.11
https://github.com/VanOord/OpenCLSim/tree/WIBO-critical-path-cosmetics
* the vessel specifications can be imported from an external file

I made a few alterations to OpenCLSim itself:
* fix a pandas indexing deprecation warning
* allow the plotly graphs to use either a dict or a list for uuids to labels

I added a io.py file next to utils for
* some mangling of the the log file
* exporting of  the tables in a datamodel in a BI tool or planning tool